### PR TITLE
MySql config changes.

### DIFF
--- a/etc/my.cnf
+++ b/etc/my.cnf
@@ -48,19 +48,19 @@ thread_cache_size = 50
 open_files_limit = 65535
 table_definition_cache = 4096
 table_open_cache = 4096
-sort_buffer_size = 2M
-join_buffer_size = 4M
+sort_buffer_size = 4M
+join_buffer_size = 8M
 read_rnd_buffer_size = 16M
 # Keep these two low, as recommended: http://stackoverflow.com/a/14652396
-tmp_table_size = 32M
-max_heap_table_size = 32M
+tmp_table_size = 64M
+max_heap_table_size = 64MB
 
 ## InnoDB
 innodb_flush_method = O_DIRECT
 innodb_log_files_in_group = 2
 innodb_log_file_size = 512M
 innodb_flush_log_at_trx_commit = 1
-innodb_open_files = 655350
+innodb_open_files = 65535
 innodb_buffer_pool_size = 2G
 # see ERROR 1114 (HY000) at line 14829: The table  is full
 #innodb_data_file_path = ibdata1:10M:autoextend
@@ -71,7 +71,7 @@ innodb_file_per_table = 1
 innodb_thread_concurrency = 0
 innodb_concurrency_tickets = 900
 innodb_commit_concurrency = 0
-innodb_thread_sleep_delay = 10000
+innodb_thread_sleep_delay = 3000
 innodb_log_buffer_size = 64M
 ##deprecated: innodb_additional_mem_pool_size = 16M
 innodb_io_capacity = 800


### PR DESCRIPTION
Changes to the `my.cnf` file that fix an error due to `innodb_open_files` setting. Increases the  `tmp_table_size` since M2 is making heavy use of temp tables in the CatalogSearch module. 

This should increase query performance and decrease queries time.